### PR TITLE
chore: move bundled Node packages to optionalDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,7 @@
       "version": "0.3.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.49",
-        "@modelcontextprotocol/sdk": "^1.0.0",
-        "cheerio": "^1.2.0",
-        "csv-parse": "^6.2.1",
-        "date-fns": "^4.1.0",
-        "lodash-es": "^4.18.1",
-        "xlsx": "^0.18.5",
-        "zod": "^4.3.6"
+        "@modelcontextprotocol/sdk": "^1.0.0"
       },
       "bin": {
         "mcp-exec": "dist/src/server.js",
@@ -36,6 +30,14 @@
       },
       "engines": {
         "node": ">=20.12.0"
+      },
+      "optionalDependencies": {
+        "cheerio": "^1.2.0",
+        "csv-parse": "^6.2.1",
+        "date-fns": "^4.1.0",
+        "lodash-es": "^4.18.1",
+        "xlsx": "^0.18.5",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1408,6 +1410,7 @@
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
       "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -1532,7 +1535,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -1598,6 +1602,7 @@
       "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
       "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "adler-32": "~1.3.0",
         "crc-32": "~1.2.0"
@@ -1643,6 +1648,7 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
       "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
@@ -1668,6 +1674,7 @@
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
@@ -1718,6 +1725,7 @@
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
       "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -1814,6 +1822,7 @@
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1840,6 +1849,7 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
       "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -1856,6 +1866,7 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "engines": {
         "node": ">= 6"
       },
@@ -1867,13 +1878,15 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
       "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -1933,6 +1946,7 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -1952,13 +1966,15 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -1974,6 +1990,7 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -2024,6 +2041,7 @@
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
       "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "whatwg-encoding": "^3.1.1"
@@ -2037,6 +2055,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2049,6 +2068,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -2336,6 +2356,7 @@
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
       "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -2562,6 +2583,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -2574,6 +2596,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -2875,7 +2898,8 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -3164,6 +3188,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -3250,6 +3275,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -3262,6 +3288,7 @@
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
       "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "domhandler": "^5.0.3",
         "parse5": "^7.0.0"
@@ -3275,6 +3302,7 @@
       "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
       "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "parse5": "^7.0.0"
       },
@@ -3287,6 +3315,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -3860,6 +3889,7 @@
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
       "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "frac": "~1.1.2"
       },
@@ -4103,6 +4133,7 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
       "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -4717,6 +4748,7 @@
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -4729,6 +4761,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4741,6 +4774,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4782,6 +4816,7 @@
       "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
       "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -4791,6 +4826,7 @@
       "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
       "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -4855,6 +4891,7 @@
       "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
       "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "adler-32": "~1.3.0",
         "cfb": "~1.2.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "^0.0.49",
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "optionalDependencies": {
     "cheerio": "^1.2.0",
     "csv-parse": "^6.2.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
## Summary
- Moves `cheerio`, `csv-parse`, `date-fns`, `lodash-es`, `xlsx`, `zod` from `dependencies` to `optionalDependencies`
- Core server deps (`@anthropic-ai/sandbox-runtime`, `@modelcontextprotocol/sdk`) remain required
- Zero behavioral change — optional deps still install by default with `npm install`; users can skip with `--no-optional` for a lighter footprint

Closes mcp-exec-mvd

## Summary by Sourcery

Build:
- Reclassify cheerio, csv-parse, date-fns, lodash-es, xlsx, and zod from dependencies to optionalDependencies in package.json and update the lockfile accordingly.